### PR TITLE
add missing comma, that breaks installing on arch via PKGBUILD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     ],
     python_requires='>=3.6, <4',
     install_requires=[
-        'click'
+        'click',
         'setuptools'
     ],
     entry_points={


### PR DESCRIPTION
Hello was installing upp on arch via PKGBUILD by modifying it to use git instead of release. 

Build would work but running upp would fail with following error.
```~/b/upliftpowerplay (master)> upp
Traceback (most recent call last):
  File "/usr/bin/upp", line 33, in <module>
    sys.exit(load_entry_point('upp==0.0.7.post2', 'console_scripts', 'upp')())
  File "/usr/bin/upp", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib/python3.9/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/usr/lib/python3.9/site-packages/upp/upp.py", line 7, in <module>
    import pkg_resources
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 3239, in <module>
    def _initialize_master_working_set():
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 3222, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 3251, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 567, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 884, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 770, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'clicksetuptools' distribution was not found and is required by upp
```

After poking around a bit found the missing comma to be the culprit. 

*edit formatting + aur package in question https://aur.archlinux.org/packages/upliftpowerplay/