### PR TITLE
Add option to read param=value pairs from configuration file and add systemd unit to apply configuration at boot

### DIFF
--- a/card0.conf
+++ b/card0.conf
@@ -1,2 +1,0 @@
-/smc_pptable/FanAcousticLimitRpm=1500
-/smc_pptable/FanTargetTemperature=70

--- a/card0.conf
+++ b/card0.conf
@@ -1,0 +1,2 @@
+/smc_pptable/FanAcousticLimitRpm=1500
+/smc_pptable/FanTargetTemperature=70

--- a/src/upp/upp.py
+++ b/src/upp/upp.py
@@ -414,7 +414,7 @@ def set(ctx, variable_path_set, to_registry, write, from_conf):
     --write option is set.
 
     It is possible to set parameters from a configuration file with one
-    "/<param>=<value>" per line using -c/--from-config instead of directly 
+    "/<param>=<value>" per line using -c/--from-conf instead of directly 
     passing parameters from command line
 
     \b
@@ -433,7 +433,7 @@ def set(ctx, variable_path_set, to_registry, write, from_conf):
 
     if from_conf is not None:
         if (len(variable_path_set) > 0):
-            print("ERROR: VARIABLE_PATH_SET found when using -c/--from-config.")
+            print("ERROR: VARIABLE_PATH_SET found when using -c/--from-conf.")
             return 2
         if not os.path.isfile(from_conf):
             print("ERROR: file {} not found.".format(from_conf))

--- a/src/upp/upp.py
+++ b/src/upp/upp.py
@@ -386,7 +386,7 @@ def get(ctx, variable_path_set):
             print('{:n}'.format(res['value']))
         else:
             print('ERROR: Incorrect variable path:', set_pair_str)
-            return 2
+            exit(2)
 
     return 0
 
@@ -434,15 +434,15 @@ def set(ctx, variable_path_set, to_registry, write, from_conf):
     if from_conf is not None:
         if (len(variable_path_set) > 0):
             print("ERROR: VARIABLE_PATH_SET found when using -c/--from-conf.")
-            return 2
+            exit(2)
         if not os.path.isfile(from_conf):
             print("ERROR: file {} not found.".format(from_conf))
-            return 2
+            exit(2)
         with open(from_conf, 'r') as config:
             variable_path_set = config.read().splitlines()
     elif (len(variable_path_set) == 0):
         print("ERROR: no parameters given to set to pp table.")
-        return 2
+        exit(2)
 
     set_pairs = []
     for set_pair_str in variable_path_set:
@@ -457,9 +457,9 @@ def set(ctx, variable_path_set, to_registry, write, from_conf):
                     set_pairs += [var_path + [float(val)]]
             else:
                 print('ERROR: Incorrect variable path:', var)
-                return 2
+                exit(2)
         else:
-            return 2
+            exit(2)
 
     pp_bytes = decode._read_binary_file(pp_file)
     data = decode.select_pp_struct(pp_bytes)

--- a/src/upp/upp.py
+++ b/src/upp/upp.py
@@ -439,7 +439,7 @@ def set(ctx, variable_path_set, to_registry, write, from_conf):
             print("ERROR: file {} not found.".format(from_conf))
             exit(2)
         with open(from_conf, 'r') as config:
-            variable_path_set = config.read().splitlines()
+            variable_path_set = list(filter(''.__ne__, config.read().splitlines()))
     elif (len(variable_path_set) == 0):
         print("ERROR: no parameters given to set to pp table.")
         exit(2)

--- a/src/upp/upp.py
+++ b/src/upp/upp.py
@@ -392,13 +392,15 @@ def get(ctx, variable_path_set):
 
 
 @click.command(short_help='Set value to PowerPlay parameter(s).')
-@click.argument('variable-path-set', nargs=-1, required=True)
+@click.argument('variable-path-set', nargs=-1, required=False)
 @click.option('-w', '--write', is_flag=True,
               help='Write changes to PP binary.', default=False)
 @click.option('-t', '--to-registry', metavar='<filename>',
               help='Output to Windows registry .reg file.')
+@click.option('-c', '--from-conf', metavar='<filename>',
+              help='Input VARIABLE_PATH_SET from file.')
 @click.pass_context
-def set(ctx, variable_path_set, to_registry, write):
+def set(ctx, variable_path_set, to_registry, write, from_conf):
     """Sets value to one or multiple PP parameters
 
     The parameter path and value must be specified in
@@ -411,6 +413,13 @@ def set(ctx, variable_path_set, to_registry, write):
     The PP tables will not be changed unless additional
     --write option is set.
 
+    It is possible to set parameters from a configuration file with one
+    "/<param>=<value>" per line using -c/--from-config instead of directly 
+    passing parameters from command line
+
+    \b
+        upp set --from-conf=card0.conf
+
     Optionally, if -t/--to-registry output is specified, an additional Windows
     registry format file with '.reg' extension will be generated, for example:
 
@@ -421,6 +430,20 @@ def set(ctx, variable_path_set, to_registry, write):
     """
     debug = ctx.obj['DEBUG']
     pp_file = ctx.obj['PPBINARY']
+
+    if from_conf is not None:
+        if (len(variable_path_set) > 0):
+            print("ERROR: VARIABLE_PATH_SET found when using -c/--from-config.")
+            return 2
+        if not os.path.isfile(from_conf):
+            print("ERROR: file {} not found.".format(from_conf))
+            return 2
+        with open(from_conf, 'r') as config:
+            variable_path_set = config.read().splitlines()
+    elif (len(variable_path_set) == 0):
+        print("ERROR: no parameters given to set to pp table.")
+        return 2
+
     set_pairs = []
     for set_pair_str in variable_path_set:
         var, val = _validate_set_pair(set_pair_str)

--- a/upliftpowerplay@.service
+++ b/upliftpowerplay@.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Uplift Power Play
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/upp --pp-file=/sys/class/drm/%i/device/pp_table set --from-config=/etc/upliftpowerplay/%i.conf
+
+[Install]
+WantedBy=multi-user.target

--- a/upliftpowerplay@.service
+++ b/upliftpowerplay@.service
@@ -3,7 +3,7 @@ Description=Uplift Power Play
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/upp --pp-file=/sys/class/drm/%i/device/pp_table set --from-config=/etc/upliftpowerplay/%i.conf
+ExecStart=/usr/bin/upp --pp-file=/sys/class/drm/%i/device/pp_table set --from-conf=/etc/upliftpowerplay/%i.conf
 
 [Install]
 WantedBy=multi-user.target

--- a/upliftpowerplay@.service
+++ b/upliftpowerplay@.service
@@ -3,7 +3,7 @@ Description=Uplift Power Play
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/upp --pp-file=/sys/class/drm/%i/device/pp_table set --from-conf=/etc/upliftpowerplay/%i.conf
+ExecStart=/usr/bin/upp --pp-file=/sys/class/drm/%i/device/pp_table set --from-conf=/etc/upliftpowerplay/%i.conf --write
 
 [Install]
 WantedBy=multi-user.target

--- a/upliftpowerplay@.service
+++ b/upliftpowerplay@.service
@@ -3,7 +3,9 @@ Description=Uplift Power Play
 
 [Service]
 Type=oneshot
+ExecStartPre=/usr/bin/bash -c "echo "profile_peak" > /sys/class/drm/card0/device/power_dpm_force_performance_level"
 ExecStart=/usr/bin/upp --pp-file=/sys/class/drm/%i/device/pp_table set --from-conf=/etc/upliftpowerplay/%i.conf --write
+ExecStopPost=/usr/bin/bash -c "echo "auto" > /sys/class/drm/card0/device/power_dpm_force_performance_level"
 
 [Install]
 WantedBy=multi-user.target

--- a/upliftpowerplay@.service
+++ b/upliftpowerplay@.service
@@ -1,11 +1,13 @@
 [Unit]
 Description=Uplift Power Play
+Before=amdgpu-clocks.service
+Wants=modprobe@amdgpu.service
 
 [Service]
 Type=oneshot
-ExecStartPre=/usr/bin/bash -c "echo "profile_peak" > /sys/class/drm/card0/device/power_dpm_force_performance_level"
+ExecStartPre=/usr/bin/bash -c "echo "profile_peak" > /sys/class/drm/%i/device/power_dpm_force_performance_level"
 ExecStart=/usr/bin/upp --pp-file=/sys/class/drm/%i/device/pp_table set --from-conf=/etc/upliftpowerplay/%i.conf --write
-ExecStopPost=/usr/bin/bash -c "echo "auto" > /sys/class/drm/card0/device/power_dpm_force_performance_level"
+ExecStopPost=/usr/bin/bash -c "echo "auto" > /sys/class/drm/%i/device/power_dpm_force_performance_level"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR includes the following changes:

* Add `upp set -c/--from-conf <file>` that reads a configuration file with `param=value` pairs in each line and applies just as `upp set` does. An example configuration file could have:
```
/smc_pptable/FanAcousticLimitRpm=2550
/smc_pptable/FanTargetTemperature=70
```

* Replace all `return 2` by `exit(2)` to properly signalize parent process with INVALID ARGUMENT return code

* Add a systemd unit to apply pp configurations at boot. This unit is called `upliftpowerplay@.service` and should be copied to `/etc/systemd/system/upliftpowerplay@.service` by users or to  `/usr/lib/systemd/system/upliftpowerplay@.service` by package maintainers. This unit should be started (to apply once) or enabled (to apply at boot) with a card instance (as in `/sys/class/drm/<card>`), e.g. `systemctl enable upliftpowerplay@card0.service`. This unit will read the configuration file in `/etc/upliftpowerplay/<card>.conf` and set the desired parameters.

* Note that the systemd unit sets the DPM to `profile_peak` before applying upp to avoid the graphics driver crashing due to SMU in sleep mode (see #32 and #37). After applying, it restores to "auto," so users must consider whether a different DPM configuration is applied before the unit is invoked at boot (e.g. in a udev rule).